### PR TITLE
Add configure steps to cpan-test.yml workflow

### DIFF
--- a/.github/workflows/cpan-test.yml
+++ b/.github/workflows/cpan-test.yml
@@ -32,6 +32,16 @@ jobs:
         run: perl -V
       - name: Install modules
         run: cpanm --notest --installdeps .
+      - name: Configure with Build.PL
+        if: ${{ hashFiles('Build.PL') != '' }}
+        run: |
+          perl Build.PL
+          ./Build
+      - name: Configure with Makefile.PL
+        if: ${{ hashFiles('Makefile.PL') != '' }}
+        run: |
+          perl Makefile.PL
+          make
       - name: Run tests
         run: prove -lv t
       - name: Archive CPAN logs on Windows

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ in the workflow. You can see the format of these lists from their default values
 * ***perl_version:*** "['5.24', '5.26', '5.28', '5.30', '5.32', '5.34', '5.36', '5.38']"
 * ***os:*** "['windows-latest', 'macos-latest', 'ubuntu-latest']"
 
+*Note:* The `cpan-test` workflow now includes configure steps to run `perl Build.PL` if `Build.PL` exists, and `perl Makefile.PL` if `Makefile.PL` exists, before running `prove`.
+
 ##### Todo
 
 * A way to install other CPAN modules (ones that, for some reason, aren't in the prereqs)


### PR DESCRIPTION
Fixes #7

Add configure steps to the `cpan-test.yml` workflow to run `perl Build.PL` or `perl Makefile.PL` if they exist before running tests.

* **README.md**
  - Add a note about the new configure steps in the `cpan-test` workflow.

* **.github/workflows/cpan-test.yml**
  - Add a step to run `perl Build.PL` and `./Build` if `Build.PL` exists.
  - Add a step to run `perl Makefile.PL` and `make` if `Makefile.PL` exists.
  - Ensure the configure/build steps are executed before running `prove`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/github_workflows/issues/7?shareId=6f03ef59-ec30-4c39-acc9-8274b65366c4).