### PR TITLE
Fix cpanm call to include --with-configure and --with-develop options

### DIFF
--- a/.github/workflows/cpan-test.yml
+++ b/.github/workflows/cpan-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Perl version
         run: perl -V
       - name: Install modules
-        run: cpanm --notest --installdeps .
+        run: cpanm --notest --with-configure --with-develop --no-man-pages --installdeps .
       - name: Configure with Build.PL
         if: ${{ hashFiles('Build.PL') != '' }}
         run: |


### PR DESCRIPTION
Fixes #6

Update the `cpanm` call in the `.github/workflows/cpan-test.yml` to include additional options for installing configure and develop dependencies.

* Modify the `Install modules` step to include `--with-configure`, `--with-develop`, and `--no-man-pages` options in the `cpanm` call.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/github_workflows/issues/6?shareId=43aa4419-b6ab-40bb-8d64-5b8c827d1aa2).