### PR TITLE
Improve "Run tests" step and question the use of prove

### DIFF
--- a/.github/workflows/cpan-test.yml
+++ b/.github/workflows/cpan-test.yml
@@ -43,7 +43,7 @@ jobs:
           perl Makefile.PL
           make
       - name: Run tests
-        run: prove -lv t
+        run: prove --blib --verbose t
       - name: Archive CPAN logs on Windows
         if: ${{ failure() && matrix.os == 'windows-latest' }}
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ in the workflow. You can see the format of these lists from their default values
 ##### Todo
 
 * A way to install other CPAN modules (ones that, for some reason, aren't in the prereqs)
-* A way to install other required softare
+* A way to install other required software
 
 #### cpan-coverage
 
@@ -91,7 +91,7 @@ runs the CPAN test, coverage and `perlcritic` workflows would look like this:
       workflow_dispatch:
 
     jobs:
-      build:
+      test:
         uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-test.yml@main
 
       coverage:


### PR DESCRIPTION
This PR improves the "Run tests" step slightly. But: If we are using the different installers (Module::Build, ExtUtils::MakeMaker) to run the configure step (that's totally correct!) why are we not using them too to run the tests

```
./Build verbose=1 test   # if Module::Build is the installer
make TEST_VERBOSE=1 test # if ExtUtils::MakeMaker is the installer
```
Instead we are using **prove**?!
