### PR TITLE
Fix check for not windows

### DIFF
--- a/.github/workflows/cpan-test.yml
+++ b/.github/workflows/cpan-test.yml
@@ -50,7 +50,7 @@ jobs:
           ./Build
           - name: Set testing contexts
       - name: Set testing context
-        if: "!startsWith(matrix.os, 'windows')"
+        if: ${{ !startsWith(matrix.os, 'windows') }}
         run: |
           printf '%s\n' '${{ inputs.testing_context }}' | \
           jq -r '.[]' | \


### PR DESCRIPTION
vscode was showing an error for line 53 in cpan-testing. I think the fix is correct, at least vscode doesn't complain any more.