### PR TITLE
new workflows with: setting arbitrary env vars, determine available perl versions dynamically

### DIFF
--- a/.github/workflows/cpan-coverage-env.yml
+++ b/.github/workflows/cpan-coverage-env.yml
@@ -1,0 +1,37 @@
+name: Test Coverage
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: false
+        type: string
+        default: '{}'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    container: davorg/perl-coveralls:latest
+    name: Test coverage
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set environment
+        shell: perl {0}
+        run: |
+          use JSON::PP;   
+          my $context = decode_json('${{ inputs.environment }}');
+          if (%$context) {
+            open(my $fh, '>>', $ENV{GITHUB_ENV}); 
+            for my $item ( keys %$context ) {
+              print $fh "$item=$context->{$item}\n";
+            }
+          }
+      - name: Install modules
+        run: cpanm -n --installdeps .
+      - name: Coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cover -test -report Coveralls

--- a/.github/workflows/cpan-test-env.yml
+++ b/.github/workflows/cpan-test-env.yml
@@ -1,0 +1,104 @@
+name: Unit tests
+
+on:
+  workflow_call:
+    inputs:
+      perl_version:
+        required: false
+        type: string
+        default: '[]'
+      os:
+        required: false
+        type: string
+        default: '["windows-latest", "macos-latest", "ubuntu-latest"]'
+      environment:
+        required: false
+        type: string
+        default: '{}'
+
+jobs:
+
+  get_versions:
+    # either use the version list provided via inputs
+    # or determine available versions >= 5.24 via Actions::Core
+    name: get perl versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-setup-perl@v1
+      - id: get-versions
+        name: get perl versions
+        shell: perl {0}
+        run: |
+          use Actions::Core;
+          use JSON::PP qw(decode_json encode_json);
+          use version;   
+          my $versions = decode_json('${{ inputs.perl_version }}');
+          @$versions = grep { version->parse($_) >= '5.24.0' } perl_versions() unless @$versions;  
+          print "Versions: ", encode_json($versions), "\n";   
+          set_output(versions => $versions);
+    outputs:
+      versions: ${{ steps.get-versions.outputs.versions }}
+
+  testing:
+    runs-on: ${{ matrix.os }}
+    needs: get_versions
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+        perl: ${{ fromJson(needs.get_versions.outputs.versions) }}
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Perl version
+        run: perl -V
+      - name: Set environment
+        shell: perl {0}
+        run: |
+          use Actions::Core;
+          use JSON::PP qw(decode_json);      
+          my $context = decode_json('${{ inputs.environment }}');
+          if (%$context) {
+            for my $item ( keys %$context ) {
+              export_variable($item, $context->{$item});
+            }
+          }
+      - name: Install modules
+        run: cpanm --notest --with-configure --with-develop --no-man-pages --installdeps .
+      - name: Configure with Makefile.PL
+        id: configure-with-eumm
+        if: ${{ hashFiles('Makefile.PL') != '' }}
+        run: |
+          perl Makefile.PL
+          make
+      - name: Configure with Build.PL
+        id: configure-with-mb
+        if: ${{ hashFiles('Build.PL') != '' }}
+        run: |
+          perl Build.PL
+          ./Build
+      - name: Run tests with make
+        if: steps.configure-with-eumm.outcome == 'success'
+        run : |
+          make TEST_VERBOSE=1 test
+      - name: Run tests with ./Build
+        if: steps.configure-with-mb.outcome == 'success'
+        run : |
+          ./Build verbose=1 test
+      - name: Archive CPAN logs on Windows
+        if: ${{ failure() && matrix.os == 'windows-latest' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpan_log
+          path: C:\Users\RUNNER~1\.cpanm\work\*\build.log
+          retention-days: 5
+      - name: Archive CPAN logs on Unix
+        if: ${{ failure() && matrix.os != 'windows-latest' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpan_log
+          path: /home/runner/.cpanm/work/*/build.log
+          retention-days: 5


### PR DESCRIPTION
I added new workflows, since I introduced braking changes.
Having done that I changed `testing_context` to `environment` as well.
Should you want to accept the PR, I could update the README.md as well.

Environment vars can be set with:
``` yaml
    with:
      os: '["ubuntu-latest"]'
      environment: |
        {
          "MY_TEST_VAR": "MY_TEST_VALUE",
          "SECOND_VAR": "SECOND_VALUE"
        }

```